### PR TITLE
rename master to main

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Contributions to rust-vmm are welcome!
 ## Merging code in rust-vmm
 
 To contribute to rust-vmm, you need to open a Pull Request (PR) against the
-master branch of the repositories. rust-vmm uses the
+main branch of the repositories. rust-vmm uses the
 [fork and pull development model](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-collaborative-development-models).
 
 We ask you to only open PRs from your fork branches. This helps us keep the
@@ -79,10 +79,10 @@ cd rust-vmm-ci
 OLD_COMMIT=`git rev-parse HEAD`
 ```
 
-3. Update rust-vmm-ci to the latest commit on master:
+3. Update rust-vmm-ci to the latest commit on main:
 
 ```bash
-git pull https://github.com/rust-vmm/rust-vmm-ci/ master
+git pull https://github.com/rust-vmm/rust-vmm-ci/ main
 ```
 
 4. Get the pretty print of commits (this helps us keep track of updates):

--- a/docs/maintainers/setup_new_repo.md
+++ b/docs/maintainers/setup_new_repo.md
@@ -30,7 +30,7 @@ also add the person requesting the crate as an Admin.
 ## Configure Repository
 
 This configuration is in line with the rust-vmm
-[contributing guidelines](https://github.com/rust-vmm/community/blob/master/CONTRIBUTING.md#merging-code-in-rust-vmm),
+[contributing guidelines](https://github.com/rust-vmm/community/blob/main/CONTRIBUTING.md#merging-code-in-rust-vmm),
 and it is necessary for ensuring that all rust-vmm crates keep the same quality
 standard.
 


### PR DESCRIPTION
We need to update the documentation to point to main as the default branch.