### PR TITLE
docs: avoid suggesting to push all tags

### DIFF
--- a/docs/crate_release.md
+++ b/docs/crate_release.md
@@ -91,9 +91,9 @@ Fixed
 - Fixed #42, the worst bug ever.
 ```
 
-7. Push the tag to the upstream repository: `git push upstream --tags`. In this
-   example, the upstream remote points to the original repository (not your
-   fork).
+7. Push the tag to the upstream repository: `git push upstream vm-awesome-v1.2.0`.
+   In this example, the upstream remote points to the original repository
+   (not your fork).
 
 8. Create a GitHub release. Go to the Releases page in the crate's repository
    and click Draft a new release (button on the right). In Tag version, pick


### PR DESCRIPTION
`git push --tags ...` pushes all refs under refs/tags. So even local development tags could be pushed by mistake. Let's avoid this by suggesting to push only the newly created tag.
