### PR TITLE
MAINTAINERS.md: open inactive issues to rel repo

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -226,7 +226,7 @@ Gatekeepers may get assigned as PR reviewers when a rust-vmm
 repository is lacking code owners, or when a previously assigned reviewer is not
 able to review a pending PR.
 
-If you want to adopt repsonsibility to help with the project, it is preferable
+If you want to adopt responsibility to help with the project, it is preferable
 to
 [become a repository maintainers instead](#becoming-a-repository-maintainer).
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -76,7 +76,7 @@ A CODEOWNER is considered inactive after **1 year** without any review activity
 
 1. Regular checks (e.g. monthly) will identify CODEOWNERS who haven't been
    active in a year
-2. An issue will be opened in the community repository tagging all inactive
+2. An issue will be opened in the affected repository tagging all inactive
    CODEOWNERS
 3. After a 1-month notification period, inactive members will be gracefully
    removed from the `CODEOWNERS` file
@@ -146,7 +146,7 @@ The script will:
 ### Notification Issue Template
 
 When inactive CODEOWNERS are identified, an issue should be created in the
-community repository using this template:
+affected repository using this template:
 
 ```markdown
 Title: Inactive CODEOWNERS Notification - [Month Year]
@@ -194,7 +194,7 @@ Title: Remove inactive CODEOWNERS - [Month Year]
 # Remove Inactive CODEOWNERS
 
 This PR removes CODEOWNERS who have been inactive for over 1 year and were
-notified in https://github.com/rust-vmm/community/issues/[issue-number].
+notified in #[issue-number].
 
 ## Changes
 
@@ -204,7 +204,7 @@ notified in https://github.com/rust-vmm/community/issues/[issue-number].
 
 ## Notification
 
-All affected CODEOWNERS were notified on [date] via https://github.com/rust-vmm/community/issues/[issue-number]
+All affected CODEOWNERS were notified on [date] via #[issue-number]
 and given a 1-month period to respond.
 
 ## Policy Reference

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -47,7 +47,7 @@ a code owner, open a PR in the target repository, add their GitHub handle in
 the `CODEOWNERS` file, and ask that person to formally approve the PR as
 acknowledgement that they agree with the role.
 2. Irrespective of who created the PR, all existing code owners (as defined in
-the`CODEOWNERS` file) must approve the PR before it is merged. In case
+the `CODEOWNERS` file) must approve the PR before it is merged. In case
 there are no code owners in the repository, ask [2 gatekeepers](#gatekeepers)
 to approve the PR for you.
 3. Once the PR is merged, ask one of the existing code owners to grant you

--- a/docs/handling_security_vulnerability_disclosures.md
+++ b/docs/handling_security_vulnerability_disclosures.md
@@ -19,7 +19,7 @@ shift to treating as a public issue.
   ```
 - Do not yank versions of crates.
   This is to avoid complication and forcing additional work on users.
-  A security conscious project is expected to be aware of security vulnerabilties via tooling such as [cargo-audit](https://github.com/RustSec/rustsec/tree/main/cargo-audit).
+  A security conscious project is expected to be aware of security vulnerabilities via tooling such as [cargo-audit](https://github.com/RustSec/rustsec/tree/main/cargo-audit).
 - Due to the CI setup it is required bypass branch protections to merge fixes implemented in private
   forks under security advisories.
 


### PR DESCRIPTION
Open inactive CODEOWNERS issues in relevant repo instead of the community repository. Otherwise there's no indication which repository we're talking about in the template notice.

(The alternative would be to open them all to community repo but mention the affected repository in the template)

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
