### PR TITLE
MAINTAINERS: add Ruoqing He as gatekeeper

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -243,10 +243,11 @@ to
 - [Paolo Bonzini](https://github.com/bonzini)
 - [Patrick Roy](https://github.com/roypat)
 - [Rob Bradford](https://github.com/rbradford)
+- [Ruoqing He](https://github.com/RuoqingHe)
 - [Samuel Ortiz](https://github.com/sameo)
 - [Sebastien Boeuf](https://github.com/sboeuf)
 - [Stefano Garzarella](https://github.com/stefano-garzarella)
 - [Jonathan Woollett-Light](https://github.com/JonathanWoollett-Light)
 - [Zach Reizner](https://github.com/zachreizner)
 
-[^1]: As of 2026/04/23
+[^1]: As of 2026/07/16


### PR DESCRIPTION
Ruoqing has been active in the community for several years. He started out by helping to support RISC-V in our CI and in various projects. He is very active and is doing a great job helping with the mono-repo, so he is an ideal candidate to help maintain the entire rust-vmm project.
